### PR TITLE
Fix for issue #5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ukbrapR
 Title: R functions to use in the UK Biobank Research Analysis Platform (RAP)
-Version: 0.2.0.9000
+Version: 0.2.1
 Authors@R: c(person("Luke", "Pilling", 
                     email = "L.Pilling@exeter.ac.uk", 
                     role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ukbrapR
 Title: R functions to use in the UK Biobank Research Analysis Platform (RAP)
-Version: 0.2.0
+Version: 0.2.0.9000
 Authors@R: c(person("Luke", "Pilling", 
                     email = "L.Pilling@exeter.ac.uk", 
                     role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# ukbrapR v0.2.0.9000 (10 August 2024)
+
+### Bug fix 
+ - Fix for issue #5 where the file paths for exported tables is not correctly specified in later calls of `get_diagnoses()`. Thanks to @LauricF for highlighting.
+
+
 # ukbrapR v0.2.0 (30 July 2024)
 
 This is a major update as I move away from using Spark as the default environment, mostly due to the cost implications; it is significantly cheaper (and quicker!) to store and search exported raw text files in the RAP persistant storage than do everything in a Spark environment (plus the added benefit that the RStudio interface is available in "normal" instances). 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
-# ukbrapR v0.2.0.9000 (10 August 2024)
+# ukbrapR v0.2.1 (10 August 2024)
 
 ### Bug fix 
- - Fix for issue #5 where the file paths for exported tables is not correctly specified in later calls of `get_diagnoses()`. Thanks to @LauricF for highlighting.
+ - Fix for issue #5. The file paths for exported tables were not correctly specified in later calls of `get_diagnoses()` when the working directory is not the home directory. Thanks to @LauricF for highlighting.
 
 
 # ukbrapR v0.2.0 (30 July 2024)

--- a/R/get_diagnoses.R
+++ b/R/get_diagnoses.R
@@ -220,11 +220,12 @@ get_diagnoses <- function(
 			cli::cli_progress_done()
 			options(cli.progress_show_after = 2)
 			
-			# add home directory prefix to file paths
-			file_paths$path = stringr::str_c(home_path, "/", file_paths$path)
 			if (verbose)  cli::cli_alert_info(c("Time taken so far: ", "{prettyunits::pretty_sec(as.numeric(difftime(Sys.time(), start_time, units=\"secs\")))}."))
 			
 		}
+		
+		# add home directory prefix to file paths
+		file_paths$path = stringr::str_c(home_path, "/", file_paths$path)
 		
 	}
 	

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ukbrapR <a href="https://lcpilling.github.io/ukbrapR/"><img src="man/figures/ukbrapR.png" align="right" width="150" /></a>
 
 <!-- badges: start -->
-[![](https://img.shields.io/badge/version-0.2.0-informational.svg)](https://github.com/lcpilling/ukbrapR)
+[![](https://img.shields.io/badge/version-0.2.1-informational.svg)](https://github.com/lcpilling/ukbrapR)
 [![](https://img.shields.io/github/last-commit/lcpilling/ukbrapR.svg)](https://github.com/lcpilling/ukbrapR/commits/master)
 [![](https://img.shields.io/badge/lifecycle-experimental-orange)](https://www.tidyverse.org/lifecycle/#experimental)
 [![DOI](https://zenodo.org/badge/709765135.svg)](https://zenodo.org/doi/10.5281/zenodo.11517716)

--- a/README.md
+++ b/README.md
@@ -177,4 +177,4 @@ If you need to see the previous release documentation follow the tags to the ver
 
 ## Questions and comments
 
-I am very open to suggestions and comments, either as [issues](https://github.com/lcpilling/ukbrapR/issues) or [pull requests](https://github.com/lcpilling/ukbrapR/pulls), or via e-mail L.Pilling@exeter.ac.uk
+Please report any bugs or [issues](https://github.com/lcpilling/ukbrapR/issues), and feel free to suggest changes as [pull requests](https://github.com/lcpilling/ukbrapR/pulls). Alternatively, feel free to contact me via e-mail L.Pilling@exeter.ac.uk


### PR DESCRIPTION
Fix for issue #5. The file paths for exported tables were not correctly specified in later calls of `get_diagnoses()` when the working directory is not the home directory. Thanks to @LauricF for highlighting.