### PR TITLE
Fix for issue 19

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ukbrapR
 Title: R functions to use in the UK Biobank Research Analysis Platform (RAP)
-Version: 0.2.8.9000
+Version: 0.2.9
 Authors@R: c(person("Luke", "Pilling", 
                     email = "L.Pilling@exeter.ac.uk", 
                     role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ukbrapR
 Title: R functions to use in the UK Biobank Research Analysis Platform (RAP)
-Version: 0.2.8
+Version: 0.2.8.9000
 Authors@R: c(person("Luke", "Pilling", 
                     email = "L.Pilling@exeter.ac.uk", 
                     role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
 # ukbrapR v0.2.8.9000 (9th January 2025)
 
 ### Bug fixes
- - Fix for issue #19 (thanks @nsandau) where OPCS searches were not always performed correctly if only OPCS3/4 codes were provided.
- - Fix issue with `get_df()` when "group_by" is used - some diagnoses were carried over between groups when different vocabs were needed.
+ - Fixes for issue #19 (thanks to @nsandau for the help):
+   1. Where OPCS searches were not always performed correctly if only OPCS3/4 codes were provided.
+   2. When using "group_by" in `get_df()` some diagnoses were incorrectly carried over between groups when different vocabs were provided for each group (condition). 
 
 ### Updates
  - Additional checking of `get_diagnoses()` input to abort if "blank" codes are provided to the grep.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# ukbrapR v0.2.8.9000 (9th January 2025)
+
+### Bug fixes
+ - Fix for issue #19 (thanks @nsandau) where OPCS searches were not always performed correctly if only OPCS3/4 codes were provided.
+ - Fix issue with `get_df()` when "group_by" is used - some diagnoses were carried over between groups when different vocabs were needed.
+
+### Updates
+ - Additional checking of `get_diagnoses()` input to abort if "blank" codes are provided to the grep.
+
+
 # ukbrapR v0.2.8 (05 October 2024)
 
 ### Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# ukbrapR v0.2.8.9000 (9th January 2025)
+# ukbrapR v0.2.9 (12th January 2025)
 
 ### Bug fixes
  - Fixes for issue #19 (thanks to @nsandau for the help):

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 
 ### Updates
  - Additional checking of `get_diagnoses()` input to abort if "blank" codes are provided to the grep.
+ - When getting date first from self-reported illness data exclude "year" if < 1936 (earliest birth year for any participant)
 
 
 # ukbrapR v0.2.8 (05 October 2024)

--- a/R/get_df.R
+++ b/R/get_df.R
@@ -236,6 +236,8 @@ get_df <- function(
 			
 			## hesin_oper
 			if (!is.null(diagnosis_list_sub$hesin_oper) & any(codes_sub$vocab_id %in% c("OPCS3","OPCS4")))  {  
+				
+				# get OPCS4 codes to search for
 				OPCS4s = ""
 				if (any(codes_sub$vocab_id == "OPCS4"))  {
 					OPCS4s <- codes_sub |>
@@ -246,9 +248,9 @@ get_df <- function(
 						stringr::str_remove(stringr::fixed(".")) |> 
 						stringr::str_sub(1, 5)
 				}
-				OPCS4_search = stringr::str_flatten(OPCS4s, collapse = "|")
-				diagnosis_list_sub$hesin_oper = diagnosis_list_sub$hesin_oper |> dplyr::filter(stringr::str_detect(oper4, !! OPCS4_search))
 				
+				# get OPCS3 codes to search for
+				OPCS3s = ""
 				if (any(codes_sub$vocab_id == "OPCS3"))  {
 					OPCS3s <- codes_sub |>
 						dplyr::filter(vocab_id == "OPCS3") |>
@@ -258,8 +260,11 @@ get_df <- function(
 						stringr::str_remove(stringr::fixed(".")) |> 
 						stringr::str_sub(1, 5)
 				}
+				
+				# subset hesin_oper to those matching either
+				OPCS4_search = stringr::str_flatten(OPCS4s, collapse = "|")
 				OPCS3_search = stringr::str_flatten(OPCS3s, collapse = "|")
-				diagnosis_list_sub$hesin_oper = diagnosis_list_sub$hesin_oper |> dplyr::filter(stringr::str_detect(oper3, !! OPCS3_search))
+				diagnosis_list_sub$hesin_oper = diagnosis_list_sub$hesin_oper |> dplyr::filter(stringr::str_detect(oper4, !! OPCS4_search) | stringr::str_detect(oper3, !! OPCS3_search))
 			}
 			
 			## self-reported illness 

--- a/R/get_df.R
+++ b/R/get_df.R
@@ -264,7 +264,10 @@ get_df <- function(
 				# subset hesin_oper to those matching either
 				OPCS4_search = stringr::str_flatten(OPCS4s, collapse = "|")
 				OPCS3_search = stringr::str_flatten(OPCS3s, collapse = "|")
-				diagnosis_list_sub$hesin_oper = diagnosis_list_sub$hesin_oper |> dplyr::filter(stringr::str_detect(oper4, !! OPCS4_search) | stringr::str_detect(oper3, !! OPCS3_search))
+				
+				if (OPCS4s != "" & OPCS3s == "")  diagnosis_list_sub$hesin_oper = diagnosis_list_sub$hesin_oper |> dplyr::filter(stringr::str_detect(oper4, !! OPCS4_search))
+				if (OPCS4s == "" & OPCS3s != "")  diagnosis_list_sub$hesin_oper = diagnosis_list_sub$hesin_oper |> dplyr::filter(stringr::str_detect(oper3, !! OPCS3_search))
+				if (OPCS4s != "" & OPCS3s != "")  diagnosis_list_sub$hesin_oper = diagnosis_list_sub$hesin_oper |> dplyr::filter(stringr::str_detect(oper4, !! OPCS4_search) | stringr::str_detect(oper3, !! OPCS3_search))
 			}
 			
 			## self-reported illness 

--- a/R/get_df.R
+++ b/R/get_df.R
@@ -784,8 +784,9 @@ get_selfrep_illness_df <- function(
 	}
 	
 	# determine earliest date
+	# remove if year is < 1900
 	ukb_dat <- ukb_dat |>
-		dplyr::filter(!is.na(selfrep_df)) |>
+		dplyr::filter(!is.na(selfrep_df) & selfrep_df >= 1936) |>
 		dplyr::group_by(eid) |>
 		dplyr::slice(which.min(selfrep_df)) |>
 		dplyr::ungroup()

--- a/R/get_df.R
+++ b/R/get_df.R
@@ -265,9 +265,9 @@ get_df <- function(
 				OPCS4_search = stringr::str_flatten(OPCS4s, collapse = "|")
 				OPCS3_search = stringr::str_flatten(OPCS3s, collapse = "|")
 				
-				if (OPCS4s != "" & OPCS3s == "")  diagnosis_list_sub$hesin_oper = diagnosis_list_sub$hesin_oper |> dplyr::filter(stringr::str_detect(oper4, !! OPCS4_search))
-				if (OPCS4s == "" & OPCS3s != "")  diagnosis_list_sub$hesin_oper = diagnosis_list_sub$hesin_oper |> dplyr::filter(stringr::str_detect(oper3, !! OPCS3_search))
-				if (OPCS4s != "" & OPCS3s != "")  diagnosis_list_sub$hesin_oper = diagnosis_list_sub$hesin_oper |> dplyr::filter(stringr::str_detect(oper4, !! OPCS4_search) | stringr::str_detect(oper3, !! OPCS3_search))
+				if (OPCS4s[1] != "" & OPCS3s[1] == "")  diagnosis_list_sub$hesin_oper = diagnosis_list_sub$hesin_oper |> dplyr::filter(stringr::str_detect(oper4, !! OPCS4_search))
+				if (OPCS4s[1] == "" & OPCS3s[1] != "")  diagnosis_list_sub$hesin_oper = diagnosis_list_sub$hesin_oper |> dplyr::filter(stringr::str_detect(oper3, !! OPCS3_search))
+				if (OPCS4s[1] != "" & OPCS3s[1] != "")  diagnosis_list_sub$hesin_oper = diagnosis_list_sub$hesin_oper |> dplyr::filter(stringr::str_detect(oper4, !! OPCS4_search) | stringr::str_detect(oper3, !! OPCS3_search))
 			}
 			
 			## self-reported illness 

--- a/R/get_df.R
+++ b/R/get_df.R
@@ -172,6 +172,7 @@ get_df <- function(
 			diagnosis_list_sub = diagnosis_list
 			
 			## gp clinical
+			gp_clinical_sub <- NULL
 			if (!is.null(diagnosis_list_sub$gp_clinical) & any(codes_sub$vocab_id %in% c("Read2","CTV3")))  {  
 				Read2s = ""
 				CTV3s  = ""
@@ -183,8 +184,9 @@ get_df <- function(
 					CTV3s  = codes_sub$code[codes_sub$vocab_id == "CTV3"]
 					CTV3s <- stringr::str_sub(CTV3s, 1, 5) |> unique()
 				}
-				diagnosis_list_sub$gp_clinical = diagnosis_list_sub$gp_clinical |> dplyr::filter(read_2 %in% !!Read2s | read_3 %in% !!CTV3s) 
+				gp_clinical_sub <- diagnosis_list_sub$gp_clinical |> dplyr::filter(read_2 %in% !!Read2s | read_3 %in% !!CTV3s) 
 			}
+			diagnosis_list_sub$gp_clinical <- gp_clinical_sub
 			
 			# create ICD10 search string
 			if (any(codes_sub$vocab_id == "ICD10"))  {
@@ -199,8 +201,8 @@ get_df <- function(
 			}
 			
 			## hesin_diag
+			hesin_diag_sub = NULL
 			if (!is.null(diagnosis_list_sub$hesin_diag) & any(codes_sub$vocab_id %in% c("ICD10","ICD9")))  {  
-				hesin_diag_sub = NULL
 				
 				if (any(codes_sub$vocab_id == "ICD10"))  {
 					colnames(diagnosis_list_sub$hesin_diag) = tolower(colnames(diagnosis_list_sub$hesin_diag))
@@ -223,18 +225,25 @@ get_df <- function(
 					hesin_diag_sub = rbind(hesin_diag_sub, diagnosis_list_sub$hesin_diag |> dplyr::filter(stringr::str_starts(diag_icd9, !! ICD9_search)))
 				}
 				
-				diagnosis_list_sub$hesin_diag = hesin_diag_sub
 			}
+			diagnosis_list_sub$hesin_diag <- hesin_diag_sub
 			
 			## death_cause
-			if (!is.null(diagnosis_list_sub$death_cause) & any(codes_sub$vocab_id == "ICD10"))  
-				diagnosis_list_sub$death_cause = diagnosis_list_sub$death_cause |> dplyr::filter(stringr::str_detect( cause_icd10, !! ICD10_search))
+			death_cause_sub <- NULL
+			if (!is.null(diagnosis_list_sub$death_cause) & any(codes_sub$vocab_id == "ICD10"))  {
+				death_cause_sub <- diagnosis_list_sub$death_cause |> dplyr::filter(stringr::str_detect( cause_icd10, !! ICD10_search))
+			}
+			diagnosis_list_sub$death_cause <- death_cause_sub
 			
 			## cancer_registry
-			if (!is.null(diagnosis_list_sub$cancer_registry) & any(codes_sub$vocab_id == "ICD10"))  
-				diagnosis_list_sub$cancer_registry = diagnosis_list_sub$cancer_registry |> dplyr::filter(stringr::str_detect( icd10, !! ICD10_search))  
+			cancer_registry_sub <- NULL
+			if (!is.null(diagnosis_list_sub$cancer_registry) & any(codes_sub$vocab_id == "ICD10"))  {
+				cancer_registry_sub <- diagnosis_list_sub$cancer_registry |> dplyr::filter(stringr::str_detect( icd10, !! ICD10_search))  
+			}
+			diagnosis_list_sub$cancer_registry <- cancer_registry_sub
 			
 			## hesin_oper
+			hesin_oper_sub <- NULL
 			if (!is.null(diagnosis_list_sub$hesin_oper) & any(codes_sub$vocab_id %in% c("OPCS3","OPCS4")))  {  
 				
 				# get OPCS4 codes to search for
@@ -265,22 +274,25 @@ get_df <- function(
 				OPCS4_search = stringr::str_flatten(OPCS4s, collapse = "|")
 				OPCS3_search = stringr::str_flatten(OPCS3s, collapse = "|")
 				
-				if (OPCS4s[1] != "" & OPCS3s[1] == "")  diagnosis_list_sub$hesin_oper = diagnosis_list_sub$hesin_oper |> dplyr::filter(stringr::str_detect(oper4, !! OPCS4_search))
-				if (OPCS4s[1] == "" & OPCS3s[1] != "")  diagnosis_list_sub$hesin_oper = diagnosis_list_sub$hesin_oper |> dplyr::filter(stringr::str_detect(oper3, !! OPCS3_search))
-				if (OPCS4s[1] != "" & OPCS3s[1] != "")  diagnosis_list_sub$hesin_oper = diagnosis_list_sub$hesin_oper |> dplyr::filter(stringr::str_detect(oper4, !! OPCS4_search) | stringr::str_detect(oper3, !! OPCS3_search))
+				if (OPCS4s[1] != "" & OPCS3s[1] == "")  hesin_oper_sub <- diagnosis_list_sub$hesin_oper |> dplyr::filter(stringr::str_detect(oper4, !! OPCS4_search))
+				if (OPCS4s[1] == "" & OPCS3s[1] != "")  hesin_oper_sub <- diagnosis_list_sub$hesin_oper |> dplyr::filter(stringr::str_detect(oper3, !! OPCS3_search))
+				if (OPCS4s[1] != "" & OPCS3s[1] != "")  hesin_oper_sub <- diagnosis_list_sub$hesin_oper |> dplyr::filter(stringr::str_detect(oper4, !! OPCS4_search) | stringr::str_detect(oper3, !! OPCS3_search))
 			}
+			diagnosis_list_sub$hesin_oper <- hesin_oper_sub
 			
 			## self-reported illness 
+			selfrep_illness_sub <- NULL
 			if (!is.null(diagnosis_list_sub$selfrep_illness) & any(codes_sub$vocab_id %in% c("ukb_cancer","ukb_noncancer")))  {
 				if (any(codes_sub$vocab_id == "ukb_cancer"))  {
 					codes_cancer = codes_sub$code[ codes_sub$vocab_id == "ukb_cancer" ]
-					diagnosis_list_sub$selfrep_illness = diagnosis_list_sub$selfrep_illness |> dplyr::filter(cancer_code %in% codes_cancer)
+					selfrep_illness_sub <- diagnosis_list_sub$selfrep_illness |> dplyr::filter(cancer_code %in% codes_cancer)
 				}
 				if (any(codes_sub$vocab_id == "ukb_noncancer"))  {
 					codes_noncancer = codes_sub$code[ codes_sub$vocab_id == "ukb_noncancer" ]
-					diagnosis_list_sub$selfrep_illness = diagnosis_list_sub$selfrep_illness |> dplyr::filter(noncancer_code %in% codes_noncancer)
+					selfrep_illness_sub <- diagnosis_list_sub$selfrep_illness |> dplyr::filter(noncancer_code %in% codes_noncancer)
 				}
 			}
+			diagnosis_list_sub$selfrep_illness <- selfrep_illness_sub
 			if (!any(codes_sub$vocab_id %in% c("ukb_cancer","ukb_noncancer")))  include_selfrep_illness <- FALSE
 			
 			

--- a/R/get_diagnoses.R
+++ b/R/get_diagnoses.R
@@ -107,6 +107,16 @@ get_diagnoses <- function(
 	OPCS3s      <- ""
 	OPCS4s      <- ""
 	
+	# throw error if any provided code has length 0
+	if (any(codes_df[,codes_col] == 0))  {
+		cli::cli_abort("Blank code provided. Check your input codes lists to avoid unexpected matches.")
+	}
+	
+	# warn if any provided code has length 1
+	if (any(codes_df[,codes_col] == 1))  {
+		cli::cli_warn("Some provided code(s) have length 1. Check your input codes lists and matched outputs to avoid unexpected matches.")
+	}
+	
 	# function to check for hyphens and abort if any provided 
 	# (suggests they want a range of codes. Safer to abort at ask the user to explicitly provide the codes to search for)
 	hyphen_check <- function(codes, vocab)  {

--- a/R/get_diagnoses.R
+++ b/R/get_diagnoses.R
@@ -108,12 +108,12 @@ get_diagnoses <- function(
 	OPCS4s      <- ""
 	
 	# throw error if any provided code has length 0
-	if (any(codes_df[,codes_col] == 0))  {
+	if (any(stringr::str_length(codes_df[,codes_col]) == 0))  {
 		cli::cli_abort("Blank code provided. Check your input codes lists to avoid unexpected matches.")
 	}
 	
 	# warn if any provided code has length 1
-	if (any(codes_df[,codes_col] == 1))  {
+	if (any(stringr::str_length(codes_df[,codes_col]) == 1))  {
 		cli::cli_warn("Some provided code(s) have length 1. Check your input codes lists and matched outputs to avoid unexpected matches.")
 	}
 	

--- a/R/get_diagnoses.R
+++ b/R/get_diagnoses.R
@@ -538,7 +538,9 @@ get_diagnoses <- function(
 					dplyr::mutate(eid = stringr::str_remove(eid, stringr::fixed(":"))) |>
 					dplyr::mutate(eid = as.numeric(eid))
 			}
-			hesin_oper_tbl <- hesin_oper_tbl |> dplyr::filter(oper3 %in% !!OPCS3s | stringr::str_detect(oper4, stringr::str_flatten(oper_codes, collapse = "|"))) 
+			if (OPCS4s[1] != "" & OPCS3s[1] == "")  hesin_oper_tbl <- hesin_oper_tbl |> dplyr::filter(stringr::str_detect(oper4, stringr::str_flatten(!! OPCS4s, collapse = "|"))) 
+			if (OPCS4s[1] == "" & OPCS3s[1] != "")  hesin_oper_tbl <- hesin_oper_tbl |> dplyr::filter(stringr::str_starts(oper3, stringr::str_flatten(!! OPCS3s, collapse = "|"))) 
+			if (OPCS4s[1] != "" & OPCS3s[1] != "")  hesin_oper_tbl <- hesin_oper_tbl |> dplyr::filter(stringr::str_starts(oper3, stringr::str_flatten(!! OPCS3s, collapse = "|")) | stringr::str_detect(oper4, stringr::str_flatten(!!OPCS4s, collapse = "|"))) 
 			
 			if (is.character(hesin_oper_tbl$opdate))  hesin_oper_tbl$opdate <- lubridate::dmy(hesin_oper_tbl$opdate)
 		}


### PR DESCRIPTION
# ukbrapR v0.2.9 (12th January 2025)

### Bug fixes
 - Fixes for issue #19 (thanks to @nsandau for the help):
   1. Where OPCS searches were not always performed correctly if only OPCS3/4 codes were provided.
   2. When using "group_by" in `get_df()` some diagnoses were incorrectly carried over between groups when different vocabs were provided for each group (condition). 

### Updates
 - Additional checking of `get_diagnoses()` input to abort if "blank" codes are provided to the grep.
 - When getting date first from self-reported illness data exclude "year" if < 1936 (earliest birth year for any participant)