### PR TITLE
Fix `dx` paths and add {tidyr} requirement

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ukbrapR
 Title: R functions to use in the UK Biobank Research Analysis Platform (RAP)
-Version: 0.3.8
+Version: 0.3.9
 Authors@R: c(person("Luke", "Pilling", 
                     email = "L.Pilling@exeter.ac.uk", 
                     role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,7 @@ Imports:
   stringr (>= 1.5.0), 
   purrr (>= 1.0.0), 
   lubridate (>= 1.9.0), 
+  tidyr (>= 1.3.0),
   rlang (>= 1.0.0), 
   cli (>= 3.6.1),
   prettyunits (>= 1.0.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# ukbrapR v0.3.9 (4th Dec 2025)
+
+### Changes
+ - Fix issue with `dx` paths when downloading exported data in `/ukbrapr_data`. Previous method worked fine in RStudio but not Cloud Workstation, and highlighted a dependency on relative paths for `$ dx download` internal commands.
+
+
 # ukbrapR v0.3.8 (2nd Dec 2025)
 
 ### Changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ### Changes
  - Fix issue with `dx` paths when downloading exported data in `/ukbrapr_data`. Previous method worked fine in RStudio but not Cloud Workstation, and highlighted a dependency on relative paths for `$ dx download` internal commands.
+ - Add {tidyr} package to requirements. Has always been a requirement, but now it is explicit!
 
 
 # ukbrapR v0.3.8 (2nd Dec 2025)

--- a/R/get_diagnoses.R
+++ b/R/get_diagnoses.R
@@ -251,7 +251,7 @@ get_diagnoses <- function(
 	
 	for (file in must_include)  if (! file %in% file_paths$object) cli::cli_abort("{.var file_paths} must contain {.path {file}}")
 	
-	# if files not already downloaded from RAP then copy to user's home directory
+	# if files not already downloaded from RAP then download to user's home directory
 	#   only do this if the file paths are to "ukbrapr_data"
 	files = file_paths$path[file_paths$object %in% must_include]
 	if (stringr::str_detect(files[1], "ukbrapr_data"))  {
@@ -262,25 +262,20 @@ get_diagnoses <- function(
 		
 		# do any need downloading from RAP? Or already been done?
 		#     each file now has two paths: a RAP path and a local path:
-		dx_files = NULL
-		for (file in stringr::str_c(home_path, "/", files))  if (! file.exists(file))  dx_files = c(dx_files, file)
+		dx_files   <- NULL
+		home_files <- stringr::str_c(home_path, "/", files)
+		for (ii in 1:length(files))  if (! file.exists(home_files[ii]))  dx_files = c(dx_files, files[ii])
 		
 		# if any were missing, download them
 		if (!is.null(dx_files))  {
 			
 			options(cli.progress_show_after = 0)
-			#cli::cli_progress_bar("Downloading files from the RAP", total = length(files))
 			cli::cli_progress_bar(format = "Downloading {.path {basename(file)}} from the RAP [{cli::pb_current}/{cli::pb_total}] {cli::pb_bar} {cli::pb_percent}", total = length(dx_files))
-			
-			# move to RAP directory
-			dx_pwd = system("dx pwd", intern=TRUE)
-			if (! stringr::str_detect(dx_pwd, "ukbrapr_data"))  system("dx cd ukbrapr_data")
 			
 			# copy file from RAP space to instance
 			for (file in dx_files)  {
-				#system(stringr::str_c("cp /mnt/project/", file, " ~/ukbrapr_data/"))
 				cli::cli_progress_update()
-				system(stringr::str_c("dx download \"", basename(file), "\" -o \"", home_path, "/ukbrapr_data\""))
+				system(stringr::str_c("dx download \"${DX_PROJECT_CONTEXT_ID}:/", file, "\" -o \"", home_path, "/ukbrapr_data\""))
 			}
 			cli::cli_progress_done()
 			options(cli.progress_show_after = 2)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ukbrapR <a href="https://lcpilling.github.io/ukbrapR/"><img src="man/figures/ukbrapR.png" align="right" width="150" /></a>
 
 <!-- badges: start -->
-[![](https://img.shields.io/badge/version-0.3.8-informational.svg)](https://github.com/lcpilling/ukbrapR)
+[![](https://img.shields.io/badge/version-0.3.9-informational.svg)](https://github.com/lcpilling/ukbrapR)
 [![](https://img.shields.io/github/last-commit/lcpilling/ukbrapR.svg)](https://github.com/lcpilling/ukbrapR/commits/main)
 [![](https://img.shields.io/badge/lifecycle-experimental-orange)](https://www.tidyverse.org/lifecycle/#experimental)
 [![DOI](https://zenodo.org/badge/709765135.svg)](https://zenodo.org/doi/10.5281/zenodo.11517716)


### PR DESCRIPTION
### Changes
 - Fix issue with `dx` paths when downloading exported data in `/ukbrapr_data`. Previous method worked fine in RStudio but not Cloud Workstation, and highlighted a dependency on relative paths for `$ dx download` internal commands.
 - Add {tidyr} package to requirements. Has always been a requirement, but now it is explicit!
