### PR TITLE
v0.3.11

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ukbrapR
 Title: R functions to use in the UK Biobank Research Analysis Platform (RAP)
-Version: 0.3.10
+Version: 0.3.11
 Authors@R: c(person("Luke", "Pilling", 
                     email = "L.Pilling@exeter.ac.uk", 
                     role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
-# ukbrapR v0.3.11 (3rd Feb 2026)
+# ukbrapR v0.3.11 (10th Feb 2026)
 
 ### Changes
  - Use `plink2` when creating polygenic scores. This handles effect/other allele differences more robustly
    - Returns the "scoreavgs" which is the total sum of the effect weights divided by the number of alleles
+ - Export "GP registrations" table when submitting table-exporter commands
 
 
 # ukbrapR v0.3.10 (27th Jan 2026)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# ukbrapR v0.3.11 (3rd Feb 2026)
+
+### Changes
+ - Use `plink2` when creating polygenic scores. This handles effect/other allele differences more robustly
+   - Returns the "scoreavgs" which is the total sum of the effect weights divided by the number of alleles
+
+
 # ukbrapR v0.3.10 (27th Jan 2026)
 
 ### New features

--- a/R/create_pgs.R
+++ b/R/create_pgs.R
@@ -139,9 +139,11 @@ create_pgs <- function(
   
   #
   #
-  # make bed 
+  # make bed -- if BED provided then just check plink2 is available
   if (!is_bed & source == "imputed")  ukbrapR::make_imputed_bed(in_file=varlist, out_bed=out_file, use_pos=use_imp_pos, progress=progress, verbose=verbose, very_verbose=very_verbose)
   if (!is_bed & source == "dragen")   ukbrapR::make_dragen_bed(in_file=varlist, out_bed=out_file, progress=progress, verbose=verbose, very_verbose=very_verbose)
+  if (is_bed)  ukbrapR:::prep_tools(get_plink=FALSE, get_plink2=TRUE, get_bgen=FALSE, verbose=verbose, very_verbose=very_verbose)
+
   
   # did it work?
   if (! file.exists(stringr::str_c(bed_path, ".bed")))  cli::cli_abort("Failed to make the BED. Try with `very_verbose=TRUE` to see terminal output.")

--- a/R/export_tables.R
+++ b/R/export_tables.R
@@ -168,6 +168,11 @@ export_tables_emr <- function(
 	table_exporter_command = stringr::str_c("dx run table-exporter -idataset_or_cohort_or_dashboard=", dataset, " -ientity='gp_scripts' -ioutput='gp_scripts' -ioutput_format='TSV' -icoding_option='RAW' --destination /ukbrapr_data/ --brief --yes")
 	if (verbose|submit) cli::cli_text(table_exporter_command)
 	if (submit)  system(table_exporter_command)
+	
+	if (verbose) cli::cli_alert("dx run table-exporter for 'gp_registrations'")
+	table_exporter_command = stringr::str_c("dx run table-exporter -idataset_or_cohort_or_dashboard=", dataset, " -ientity='gp_registrations' -ioutput='gp_registrations' -ioutput_format='TSV' -icoding_option='RAW' --destination /ukbrapr_data/ --brief --yes")
+	if (verbose|submit) cli::cli_text(table_exporter_command)
+	if (submit)  system(table_exporter_command)
 
 }
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ukbrapR <a href="https://lcpilling.github.io/ukbrapR/"><img src="man/figures/ukbrapR.png" align="right" width="150" /></a>
 
 <!-- badges: start -->
-[![](https://img.shields.io/badge/version-0.3.10-informational.svg)](https://github.com/lcpilling/ukbrapR)
+[![](https://img.shields.io/badge/version-0.3.11-informational.svg)](https://github.com/lcpilling/ukbrapR)
 [![](https://img.shields.io/github/last-commit/lcpilling/ukbrapR.svg)](https://github.com/lcpilling/ukbrapR/commits/main)
 [![](https://img.shields.io/badge/lifecycle-experimental-orange)](https://www.tidyverse.org/lifecycle/#experimental)
 [![DOI](https://zenodo.org/badge/709765135.svg)](https://zenodo.org/doi/10.5281/zenodo.11517716)
@@ -76,7 +76,7 @@ The highlight of developing this feature was naming the internal function `make_
 
 ### Create polygenic score
 
-`create_pgs()` takes a data frame containing a list of variant associations with a trait and creates a weighted allele score using [plink](https://www.cog-genomics.org/plink/1.9/score). By default it uses the [imputed](https://biobank.ctsu.ox.ac.uk/crystal/field.cgi?id=22828) genotypes.
+`create_pgs()` takes a data frame containing a list of variant associations with a trait and creates a weighted allele score using [plink2](https://www.cog-genomics.org/plink/2.0/score). By default it uses the [imputed](https://biobank.ctsu.ox.ac.uk/crystal/field.cgi?id=22828) genotypes.
 
 The only required input is a data frame (or path to file) containing rsid, chr, pos, effect_allele, other_allele, beta. For DRAGEN pos is build 38.
 

--- a/man/create_pgs.Rd
+++ b/man/create_pgs.Rd
@@ -53,6 +53,8 @@ A data frame
 \description{
 Use user-provided list of genetic variants with weights for a trait to create a polygenic score. Uses the imputed BGEN files (field 22828) or WGS DRAGEN BGEN files (field 24309) data and load as data.frame
 
+Uses plink2 to create the score (https://www.cog-genomics.org/plink/2.0/score). The returned score is the sum of the effect alleles weighted by the provided beta coefficients, divided by the number of non-missing alleles (i.e. the average score per allele).
+
 If selecting the DRAGEN data as the source, this assumes your project has access to the WGS BGEN files released April 2025. If not, run `ukbrapR:::make_dragen_bed_from_pvcfs()` to use [tabix] and [plink] to subset the [DRAGEN WGS pVCF files].
 }
 \examples{


### PR DESCRIPTION
 - Use `plink2` when creating polygenic scores. This handles effect/other allele differences more robustly
   - Returns the "scoreavgs" which is the total sum of the effect weights divided by the number of alleles
 - Export "GP registrations" table when submitting table-exporter commands